### PR TITLE
Define DocType on render.

### DIFF
--- a/library/Respect/Template/Document.php
+++ b/library/Respect/Template/Document.php
@@ -20,7 +20,7 @@ class Document
 	* Constants to define the docnype of the document.
 	*
 	* @link http://www.w3.org/QA/2002/04/valid-dtd-list.html
-	* @author nickl- <nick@jigsoft.co.za>
+	* @author Nick Lombard <github@jigsoft.co.za>
 	*/
 	const HTML_5 = <<<'HTML'
 <!DOCTYPE html>

--- a/library/Respect/Template/Html.php
+++ b/library/Respect/Template/Html.php
@@ -15,7 +15,7 @@ class Html extends ArrayObject
 	* Constants to define the docnype of the document.
 	*
 	* @see Document
-	* @author nickl- <nick@jigsoft.co.za>
+	* @author Nick Lombard <github@jigsoft.co.za>
 	*/
 	const HTML_5 = Document::HTML_5;
 	const HTML_4_01_STRICT = Document::HTML_4_01_STRICT;


### PR DESCRIPTION
As requested at Respect/Template#20

Added all doctypes as per http://www.w3.org/QA/2002/04/valid-dtd-list.html to Document class.
Added references to HTML type doctypes from Document class constants to Html class for convenience.
If doctype is supplied replace current doctype if it exists before prepending doctype.
Added some comments for completion.

Not sure if this is what you expected?
