### PR TITLE
Fix autoloader not finding Zend\\Dom namespace.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "brikou/zend_dom" : "*"
+        "php": ">=5.3.3"
     },
     "autoload": {
         "psr-0": {
-            "Respect\\Template": "library\/"
+            "Respect\\Template": "library\/",
+            "Zend\\Dom": "library\/"
         }
     }
 }


### PR DESCRIPTION
Based on discussion at Respect/Template#23

This fixes the problem that autoloader does not find the Zend\Dom namespace and removes the external dependency relying on the packaged zend library files.

If this library needs to stay within template due to pear or whatever reason this patch needs to be applied otherwise the fix already committed by @henriquemoody works fine but then we can delete the Zend library from Respect/Template.

What was changed:

Removed the separate requirement and added the Zend\Dom to the autoload namespace.
