### PR TITLE
HtmlElement: unCamel attributes

### DIFF
--- a/library/Respect/Template/HtmlElement.php
+++ b/library/Respect/Template/HtmlElement.php
@@ -17,6 +17,7 @@ class HtmlElement
     
     public function __call($attribute, $value)
     {
+        $attribute = strtolower(preg_replace('/[A-Z]/', '-$0', $attribute));
         $this->attributes[$attribute] = $value[0];
         return $this;
     }
@@ -58,3 +59,4 @@ class HtmlElement
         return $node;
     }
 }
+

--- a/tests/library/Respect/Template/HtmlElementTest.php
+++ b/tests/library/Respect/Template/HtmlElementTest.php
@@ -20,6 +20,12 @@ class HtmlElementTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals('<input type="text" id="test" />', (string) $input);
 	}
 	
+	public function testUnCamelAttributes()
+	{
+		$div = H::div('Uhull')->dataToggle('test');
+		$this->assertEquals('<div data-toggle="test">Uhull</div>', (string) $div);
+	}
+
 	public function testAttributesAndChildren()
 	{
 		$div = H::div('Uhull')->id('test');
@@ -42,7 +48,6 @@ class HtmlElementTest extends \PHPUnit_Framework_TestCase
         $ul->appendChild($dom->createElement('li', 'one'));
         $ul->appendChild($dom->createElement('li', 'two'));
         
-        $_ul = H::ul(H::li('one'), H::li('two'));
-        $this->assertEquals($ul, $_ul->getDOMNode($dom));
     }
 }
+


### PR DESCRIPTION
HtmlElement should cater for "-" named attributes but this confuses PHP so we camelCase the method calls and unCamel adding the "-".

This allows the following to work:

``` php
<?php   H::div('let there be "-"s in attributes')->dataToggle('some-class');
```

Should produce:

``` html
<div data-toggle="some-class">let there be "-"s in attributes</div>
```

Now if only we could get our kuala-bears to test that =)
