### PR TITLE
Allow Pseudo Selectors

### DIFF
--- a/examples/simple.php
+++ b/examples/simple.php
@@ -31,4 +31,6 @@ $template['#preamble .p1']     = H::div(
 $template['#preamble .p2'] = 'The key concept to understand Respect\Template is simple: isolation of concerns. Backend developers should handle data and serve them properly while frontend developers should do the shinning stuff (CSS and Javascript).';
 $template['#preamble .p3'] = 'Respect\Template aims to be easy to use by everyone, with minimum learning curve, minimal impact on the existing code and awesome as possible!';
 
+$template['#lselect ul li:first-child'] = H::h1('I\'m first');
+
 echo $template->render();

--- a/library/Respect/Template/Factory.php
+++ b/library/Respect/Template/Factory.php
@@ -1,0 +1,15 @@
+<?php
+namespace Respect\Template;
+
+use Respect\Template\PseudoElements;
+
+final class Factory
+{
+	private function __construct(){}
+
+	public static function PseudoElement($type)
+	{
+		if ('first-child' == $type)
+			return new PseudoElements\FirstChild();
+	}
+}

--- a/library/Respect/Template/Operation.php
+++ b/library/Respect/Template/Operation.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Respect\Template;
+
+use ReflectionClass;
+use DOMDocument;
+use DOMNode;
+
+/**
+ * An encapsulated list of named operators and it's operands (values)
+ */
+class Operation
+{
+    /**
+     * @var string Name for this operation
+     *
+     * @see Respect\Template\Html::registerOperation
+     */
+    public $name;
+    /**
+     * @var array List of operators in this operation
+     * 
+     * @see Respect\Template\Operation::__call
+     * @see Respect\Template\Operation::registerOperator
+     */
+    public $operators = array();
+    /**
+     * @var mixed Replacement data for this operation
+     */
+    public $replacement = null;
+    
+    /**
+     * @param string $operation The operation name
+     */
+    public function __construct($operation)
+    {
+        $this->name = $operation;
+    }
+    
+    /**
+     * Registers an operation
+     *
+     * @param string $operation The operation name
+     * @param array  $args      Operation constructor args
+     *
+     * @see Respect\Template\Operators
+     * @see Respect\Template\Operation::registerOperator
+     */
+    public function __call($operation, $args)
+    {
+        $this->registerOperator($operation, $args);
+        return $this;
+    }
+    
+    /**
+     * Registers an operation
+     *
+     * @param string $operation The operation name
+     * @param array  $args      Operation constructor args
+     *
+     * @see Respect\Template\Operators
+     * @see Respect\Template\Operation::__call
+     */
+    public function registerOperator($operation, $args)
+    {
+        $mirror = new ReflectionClass('Respect\\Template\\Operators\\'.ucfirst($operation));
+        $operator = $mirror->newInstanceArgs($args);
+        $this->operators[] = $operator;
+        return $operation;
+    }
+    
+    /**
+     * Feeds this operation with replacement data
+     * 
+     * @param mixed $replacement Replacement data
+     *
+     * @return Respect\Template\Operation The operation itself
+     */
+    public function feed($replacement)
+    {
+        $this->replacement = $replacement;
+        return $this;
+    }
+    
+    /**
+     * Operates this in any node
+     *
+     * @param DOMNode $context Context to be operated on
+     *
+     * @return DOMNode The operated context instance
+     *
+     * @see Respect\Template\Operation::operate
+     */
+    public function __invoke(DOMNode $context)
+    {
+        return $this->operate($context);
+    }
+    
+    /**
+     * Operates this in any node
+     *
+     * @param DOMNode $context Context to be operated on
+     *
+     * @return DOMNode The operated context instance
+     *
+     * @see Respect\Template\Operation::__invoke
+     */
+    public function operate(DOMNode $context)
+    {
+        foreach ($this->operators as $operator) {
+            $operator($context, $this->replacement);
+        }
+        return $context;
+    }
+    
+    /**
+     * Compile this operation as PHP Process Instructions on the Document
+     *
+     * @param DOMNode $context Document to be compiled on
+     *
+     * @return DOMNode The compiled document instance
+     *
+     * @see Respect\Template\Operation::compile
+     */
+    public function compile(DOMNOde $context, $name=null)
+    {
+        foreach ($this->operators as $operator) {
+            $operator->compile($context, $name ?: $this->name, $this->replacement);
+        }
+        return $context;
+    }
+}

--- a/library/Respect/Template/PseudoElements/FirstChild.php
+++ b/library/Respect/Template/PseudoElements/FirstChild.php
@@ -1,0 +1,10 @@
+<?php
+namespace Respect\Template\PseudoElements;
+
+class FirstChild implements PseudoElementsInterface
+{
+	public function apply($selector)
+	{
+		return preg_replace('/:(.+\S)/', '[1]', $selector);
+	}
+}

--- a/library/Respect/Template/PseudoElements/PseudoElementsInterface.php
+++ b/library/Respect/Template/PseudoElements/PseudoElementsInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace Respect\Template\PseudoElements;
+
+interface PseudoElementsInterface
+{
+	public function apply($selector);
+}

--- a/library/Respect/Template/Query.php
+++ b/library/Respect/Template/Query.php
@@ -32,12 +32,29 @@ class Query
 	public function getResult()
 	{
 		// Get results by a CSS selector
-		$selector = $this->selector;
+		$selector = $this->tratePseudoSelector();
 		$document = $this->document->getQueryDocument();
 		$results  = $document->execute($selector);
-		$xpath    = $results->getXpathQuery();
+		echo $xpath    = $results->getXpathQuery();
 		$domxpath = new DOMXPath($this->document->getDom());
 		$nodelist = iterator_to_array($domxpath->query($xpath));
 		return $nodelist;
+	}
+
+	private function hasPseudoSelector()
+	{
+		if (preg_match('/:(.+\S)/', $this->selector, $match)) {
+			return $match[1];
+		}
+		return false;
+	}
+
+	private function tratePseudoSelector()
+	{
+		if ($pseudoSelector = $this->hasPseudoSelector()) {
+			$pseudoSelector = Factory::PseudoElement($pseudoSelector);
+			return $pseudoSelector->apply($this->selector);
+		}
+		return $this->selector;
 	}
 }


### PR DESCRIPTION
I think that cover pseudo selectors in css template engine Respect is
very handy.
To do this, I created 2 methods in the class `Query` that comes if there
is a pseudo selector in
css selector and passes to a factory that will return the instance of a
pseudo selector and will
call the `apply` to "filter" the dial, leaving compatible with xpath.

Only did the 'first-child', do not know if this is the best way for such
a task.
Hopefully opinions and suggestions.
